### PR TITLE
Update crontab example in README.md for new path in upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ docker run -v /etc/localtime:/etc/localtime:ro -v $PWD/monitor.env:/.env:ro -v $
 with the following crontab:
 
 ```
-*/2 * * * * /tmo-monitor/tmo-monitor.py --skip-bands
-1 4 * * * /tmo-monitor/tmo-monitor.py --skip-ping
+*/2 * * * * /tmo-monitor/bin/tmo-monitor.py --skip-bands
+1 4 * * * /tmo-monitor/bin/tmo-monitor.py --skip-ping
 ```
 
 will run a ping test every 2 minutes and a band test every day at 4:01am.


### PR DESCRIPTION
I get this error
```
/bin/ash: /tmo-monitor/tmo-monitor.py: not found
```

And I found that in upstream, the path is now:
https://github.com/highvolt-dev/tmo-monitor/blob/main/bin/tmo-monitor.py

Updating the crontab example in README to include the `bin` in the command path
