### PR TITLE
'pip3 install .' instead of '-r requirements.txt'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY entrypoint.sh /
 
 RUN git clone --depth=1 https://github.com/highvolt-dev/tmo-monitor.git && \
     cd tmo-monitor && \
-    pip3 install -r requirements.txt
+    pip3 install .
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
pip3 install's `-r requirements.txt` does not seem to add the correct modules and I get error message like this:

```
tmo-monitor_1  | ModuleNotFoundError: No module named 'tmo_monitor'
tmo-monitor_1  | Traceback (most recent call last):
tmo-monitor_1  |   File "/tmo-monitor/bin/tmo-monitor.py", line 10, in <module>
tmo-monitor_1  |     from tmo_monitor.gateway.model import GatewayModel
tmo-monitor_1  | ModuleNotFoundError: No module named 'tmo_monitor'
```

Doing `pip3 install .` fixes this